### PR TITLE
Circle creation flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,11 +23,11 @@
         android:name=".QuipitApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/appName"
         android:theme="@style/AppTheme" >
         <activity
             android:name=".actvitiy.LoginActivity"
-            android:label="@string/app_name" >
+            android:label="@string/appName" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -66,7 +66,7 @@
 
         <activity
             android:name=".actvitiy.CreateCircleActivity"
-            android:label="@string/title_create_circle">
+            android:label="@string/titleCreateCircle">
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="it.quip.android" >
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -12,9 +13,12 @@
       IMPORTANT: Change "com.parse.starter.permission.C2D_MESSAGE" in the lines below
       to match your app's package name + ".permission.C2D_MESSAGE".
     -->
-    <permission android:protectionLevel="signature"
-        android:name="it.quip.android.permission.C2D_MESSAGE" />
+    <permission
+        android:name="it.quip.android.permission.C2D_MESSAGE"
+        android:protectionLevel="signature" />
+
     <uses-permission android:name="it.quip.android.permission.C2D_MESSAGE" />
+
     <application
         android:name=".QuipitApplication"
         android:allowBackup="true"
@@ -32,30 +36,38 @@
         </activity>
         <activity
             android:name=".actvitiy.QuipitHomeActivity"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar" >
         </activity>
+
         <service android:name="com.parse.PushService" />
-        <receiver android:name="com.parse.ParsePushBroadcastReceiver"
-            android:exported="false">
+
+        <receiver
+            android:name="com.parse.ParsePushBroadcastReceiver"
+            android:exported="false" >
             <intent-filter>
                 <action android:name="com.parse.push.intent.RECEIVE" />
                 <action android:name="com.parse.push.intent.DELETE" />
                 <action android:name="com.parse.push.intent.OPEN" />
             </intent-filter>
         </receiver>
-        <receiver android:name="com.parse.GcmBroadcastReceiver"
-            android:permission="com.google.android.c2dm.permission.SEND">
+        <receiver
+            android:name="com.parse.GcmBroadcastReceiver"
+            android:permission="com.google.android.c2dm.permission.SEND" >
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
                 <action android:name="com.google.android.c2dm.intent.REGISTRATION" />
 
-                <!--
-                  IMPORTANT: Change "com.parse.starter" to match your app's package name.
-                -->
+<!--                   IMPORTANT: Change "com.parse.starter" to match your app's package name. -->
                 <category android:name="it.quip.android" />
             </intent-filter>
         </receiver>
+
         <meta-data android:name="com.parse.push.notification_icon" android:resource="@drawable/ic_quipit_notification_logo"/>
+
+        <activity
+            android:name=".actvitiy.CreateCircleActivity"
+            android:label="@string/title_create_circle">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/it/quip/android/QuipitApplication.java
+++ b/app/src/main/java/it/quip/android/QuipitApplication.java
@@ -5,6 +5,9 @@ import android.app.Application;
 import com.parse.Parse;
 import com.parse.ParseInstallation;
 
+import it.quip.android.model.User;
+import it.quip.android.util.MockUtils;
+
 public class QuipitApplication extends Application {
 
     @Override
@@ -19,6 +22,10 @@ public class QuipitApplication extends Application {
 
     public String stringRes(int resId) {
         return getResources().getString(resId);
+    }
+
+    public static User getCurrentUser() {
+        return MockUtils.getUsers().get(0);
     }
 
 }

--- a/app/src/main/java/it/quip/android/actvitiy/CreateCircleActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/CreateCircleActivity.java
@@ -21,8 +21,8 @@ public class CreateCircleActivity extends AppCompatActivity {
 
     public static final String CREATED_CIRCLE = "it.quip.android.CREATED_CIRCLE";
 
-    CreateCircleFragment createCircleFragment;
-    InviteFriendsFragment inviteFriendsFragment;
+    private CreateCircleFragment createCircleFragment;
+    private InviteFriendsFragment inviteFriendsFragment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/it/quip/android/actvitiy/CreateCircleActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/CreateCircleActivity.java
@@ -39,8 +39,8 @@ public class CreateCircleActivity extends AppCompatActivity {
         inviteFriendsFragment = InviteFriendsFragment.newInstance();
 
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        ft.replace(R.id.fl_circle_info, createCircleFragment);
-        ft.replace(R.id.fl_circle_friends, inviteFriendsFragment);
+        ft.replace(R.id.flCircleInfo, createCircleFragment);
+        ft.replace(R.id.flCircleFriends, inviteFriendsFragment);
         ft.commit();
     }
 
@@ -53,7 +53,7 @@ public class CreateCircleActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.mi_create_circle:
+            case R.id.miCreateCircle:
                 createCircle();
                 return true;
         }

--- a/app/src/main/java/it/quip/android/actvitiy/CreateCircleActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/CreateCircleActivity.java
@@ -1,0 +1,76 @@
+package it.quip.android.actvitiy;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AppCompatActivity;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import java.util.List;
+
+import it.quip.android.QuipitApplication;
+import it.quip.android.R;
+import it.quip.android.fragment.CreateCircleFragment;
+import it.quip.android.fragment.InviteFriendsFragment;
+import it.quip.android.model.Circle;
+import it.quip.android.model.User;
+import it.quip.android.util.MockUtils;
+
+public class CreateCircleActivity extends AppCompatActivity {
+
+    public static final String CREATED_CIRCLE = "it.quip.android.CREATED_CIRCLE";
+
+    CreateCircleFragment createCircleFragment;
+    InviteFriendsFragment inviteFriendsFragment;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_create_circle);
+
+        if (null == savedInstanceState) {
+            setupFragments();
+        }
+    }
+
+    private void setupFragments() {
+        createCircleFragment = CreateCircleFragment.newInstance();
+        inviteFriendsFragment = InviteFriendsFragment.newInstance();
+
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.replace(R.id.fl_circle_info, createCircleFragment);
+        ft.replace(R.id.fl_circle_friends, inviteFriendsFragment);
+        ft.commit();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_create_circle, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.mi_create_circle:
+                createCircle();
+                return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void createCircle() {
+        String circleName = createCircleFragment.getCircleName();
+        List<User> invitedFriends = inviteFriendsFragment.getInvitedFriends();
+        Circle createdCircle = MockUtils.circleWithNameAndMembers(circleName, invitedFriends);
+        createdCircle.addMember(QuipitApplication.getCurrentUser());
+
+        Intent data = new Intent();
+        data.putExtra(CREATED_CIRCLE, createdCircle);
+
+        setResult(RESULT_OK, data);
+        finish();
+    }
+}

--- a/app/src/main/java/it/quip/android/actvitiy/LoginActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/LoginActivity.java
@@ -49,7 +49,7 @@ public class LoginActivity extends AppCompatActivity {
         int id = item.getItemId();
 
         //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
+        if (id == R.id.actionSettings) {
             return true;
         }
 

--- a/app/src/main/java/it/quip/android/actvitiy/LoginActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/LoginActivity.java
@@ -3,8 +3,6 @@ package it.quip.android.actvitiy;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 
@@ -34,25 +32,4 @@ public class LoginActivity extends AppCompatActivity {
         startActivity(intent);
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_login, menu);
-        return true;
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
-
-        //noinspection SimplifiableIfStatement
-        if (id == R.id.actionSettings) {
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
-    }
 }

--- a/app/src/main/java/it/quip/android/actvitiy/QuipitHomeActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/QuipitHomeActivity.java
@@ -30,9 +30,9 @@ public class QuipitHomeActivity extends AppCompatActivity {
     private User user;
 
     private Toolbar mToolbar;
-    private DrawerLayout dlDrawer;
+    private DrawerLayout mDrawerLayout;
     private ActionBarDrawerToggle mDrawerToggle;
-    private NavigationView nvDrawer;
+    private NavigationView mNavDrawer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -51,11 +51,11 @@ public class QuipitHomeActivity extends AppCompatActivity {
         mToolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(mToolbar);
 
-        dlDrawer = (DrawerLayout) findViewById(R.id.drawer_layout);
+        mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         mDrawerToggle = setupDrawerToggle();
-        dlDrawer.setDrawerListener(mDrawerToggle);
+        mDrawerLayout.setDrawerListener(mDrawerToggle);
 
-        nvDrawer = (NavigationView) findViewById(R.id.nvView);
+        mNavDrawer = (NavigationView) findViewById(R.id.nvView);
         setupDrawerContent();
         updateSidebarMenu();
 
@@ -64,11 +64,11 @@ public class QuipitHomeActivity extends AppCompatActivity {
 
     private ActionBarDrawerToggle setupDrawerToggle() {
         return new ActionBarDrawerToggle(
-                this, dlDrawer, mToolbar, R.string.drawerOpen, R.string.drawerClose);
+                this, mDrawerLayout, mToolbar, R.string.drawerOpen, R.string.drawerClose);
     }
 
     private void setupDrawerContent() {
-        nvDrawer.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
+        mNavDrawer.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
             @Override
             public boolean onNavigationItemSelected(MenuItem menuItem) {
                 selectDrawerItem(menuItem);
@@ -78,7 +78,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
     }
 
     private void updateSidebarMenu() {
-        Menu circlesSubMenu = nvDrawer.getMenu().findItem(R.id.navCircles).getSubMenu();
+        Menu circlesSubMenu = mNavDrawer.getMenu().findItem(R.id.navCircles).getSubMenu();
         circlesSubMenu.clear();
 
         for (Circle circle : user.getCircles()) {
@@ -107,12 +107,16 @@ public class QuipitHomeActivity extends AppCompatActivity {
 
         menuItem.setChecked(true);
         prepareFragment(fragment).commit();
-        dlDrawer.closeDrawers();
+        mDrawerLayout.closeDrawers();
     }
 
     /**
      * Prepares a fragment to be displayed, returning the fragment transaction. It is up to the
      * callee to decide what to do with it (commit the transaction or commit allowing state loss).
+     *
+     * In some cases, we'll want to use commitAllowingStateLoss. Specifically, after the state
+     * has been saved. See these docs for more info:
+     *  http://developer.android.com/reference/android/app/FragmentTransaction.html#commitAllowingStateLoss()
      */
     private FragmentTransaction prepareFragment(Fragment fragment) {
         return prepareFragment(fragment, true);
@@ -143,7 +147,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                dlDrawer.openDrawer(GravityCompat.START);
+                mDrawerLayout.openDrawer(GravityCompat.START);
                 return true;
             case R.id.miNewCircle:
                 createCircle();

--- a/app/src/main/java/it/quip/android/actvitiy/QuipitHomeActivity.java
+++ b/app/src/main/java/it/quip/android/actvitiy/QuipitHomeActivity.java
@@ -55,7 +55,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
         mDrawerToggle = setupDrawerToggle();
         dlDrawer.setDrawerListener(mDrawerToggle);
 
-        nvDrawer = (NavigationView) findViewById(R.id.nv_view);
+        nvDrawer = (NavigationView) findViewById(R.id.nvView);
         setupDrawerContent();
         updateSidebarMenu();
 
@@ -64,7 +64,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
 
     private ActionBarDrawerToggle setupDrawerToggle() {
         return new ActionBarDrawerToggle(
-                this, dlDrawer, mToolbar, R.string.drawer_open, R.string.drawer_close);
+                this, dlDrawer, mToolbar, R.string.drawerOpen, R.string.drawerClose);
     }
 
     private void setupDrawerContent() {
@@ -78,7 +78,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
     }
 
     private void updateSidebarMenu() {
-        Menu circlesSubMenu = nvDrawer.getMenu().findItem(R.id.nav_circles).getSubMenu();
+        Menu circlesSubMenu = nvDrawer.getMenu().findItem(R.id.navCircles).getSubMenu();
         circlesSubMenu.clear();
 
         for (Circle circle : user.getCircles()) {
@@ -91,7 +91,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
 
         int itemId = menuItem.getItemId();
         switch (itemId) {
-            case R.id.nav_notifications:
+            case R.id.navNotifications:
                 fragment = new NotificationsFragment();
                 break;
             default:
@@ -120,7 +120,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
 
     private FragmentTransaction prepareFragment(Fragment fragment, boolean addToBackStack) {
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        ft.replace(R.id.fl_content, fragment);
+        ft.replace(R.id.flContent, fragment);
         if (addToBackStack) {
             ft.addToBackStack(null);
         }
@@ -145,7 +145,7 @@ public class QuipitHomeActivity extends AppCompatActivity {
             case android.R.id.home:
                 dlDrawer.openDrawer(GravityCompat.START);
                 return true;
-            case R.id.mi_new_circle:
+            case R.id.miNewCircle:
                 createCircle();
                 return true;
         }

--- a/app/src/main/java/it/quip/android/adapter/UsersArrayAdapter.java
+++ b/app/src/main/java/it/quip/android/adapter/UsersArrayAdapter.java
@@ -1,0 +1,68 @@
+package it.quip.android.adapter;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import java.util.List;
+
+import it.quip.android.R;
+import it.quip.android.model.User;
+
+public class UsersArrayAdapter extends ArrayAdapter<User> {
+
+    private OnLongClickListener onLongClickListener;
+
+    public UsersArrayAdapter(Context context, List<User> users) {
+        super(context, 0, users);
+    }
+
+    public void setOnLongClickListener(OnLongClickListener onLongClickListener) {
+        this.onLongClickListener = onLongClickListener;
+    }
+
+    @Override
+    public View getView(final int position, View convertView, ViewGroup parent) {
+        ViewHolder holder;
+        User user = getItem(position);
+
+        if (null == convertView) {
+            convertView = LayoutInflater.from(getContext())
+                    .inflate(R.layout.item_user, parent, false);
+
+            holder = new ViewHolder();
+            holder.tvName = (TextView) convertView.findViewById(R.id.tv_name);
+
+            convertView.setTag(holder);
+        } else {
+            holder = (ViewHolder) convertView.getTag();
+        }
+
+        holder.tvName.setText(user.getName());
+
+        convertView.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                if (onLongClickListener != null) {
+                    return onLongClickListener.onLongClick(position, getItem(position));
+                }
+
+                return false;
+            }
+        });
+
+        return convertView;
+    }
+
+    public interface OnLongClickListener {
+        boolean onLongClick(int position, User user);
+    }
+
+    public class ViewHolder {
+        TextView tvName;
+    }
+
+}

--- a/app/src/main/java/it/quip/android/adapter/UsersArrayAdapter.java
+++ b/app/src/main/java/it/quip/android/adapter/UsersArrayAdapter.java
@@ -34,7 +34,7 @@ public class UsersArrayAdapter extends ArrayAdapter<User> {
                     .inflate(R.layout.item_user, parent, false);
 
             holder = new ViewHolder();
-            holder.tvName = (TextView) convertView.findViewById(R.id.tv_name);
+            holder.tvName = (TextView) convertView.findViewById(R.id.tvName);
 
             convertView.setTag(holder);
         } else {

--- a/app/src/main/java/it/quip/android/fragment/CircleHeaderFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/CircleHeaderFragment.java
@@ -1,0 +1,50 @@
+package it.quip.android.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import it.quip.android.R;
+import it.quip.android.model.Circle;
+
+public class CircleHeaderFragment extends Fragment {
+
+    private static final String CIRCLE = "it.quip.android.CIRCLE";
+
+    private Circle circle;
+
+    public static CircleHeaderFragment newInstance(Circle circle) {
+        CircleHeaderFragment fragment = new CircleHeaderFragment();
+        Bundle args = new Bundle();
+        args.putParcelable(CIRCLE, circle);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        circle = getArguments().getParcelable(CIRCLE);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_circle_header, container, false);
+        setupViews(v);
+        return v;
+    }
+
+    private void setupViews(View v) {
+        TextView tvName = (TextView) v.findViewById(R.id.tv_name);
+        tvName.setText(circle.getName());
+
+        TextView tvQuipsters = (TextView) v.findViewById(R.id.tv_quipsters);
+        tvQuipsters.setText(circle.getMembers().size() + " quipsters");
+    }
+
+}

--- a/app/src/main/java/it/quip/android/fragment/CircleHeaderFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/CircleHeaderFragment.java
@@ -40,10 +40,10 @@ public class CircleHeaderFragment extends Fragment {
     }
 
     private void setupViews(View v) {
-        TextView tvName = (TextView) v.findViewById(R.id.tv_name);
+        TextView tvName = (TextView) v.findViewById(R.id.tvName);
         tvName.setText(circle.getName());
 
-        TextView tvQuipsters = (TextView) v.findViewById(R.id.tv_quipsters);
+        TextView tvQuipsters = (TextView) v.findViewById(R.id.tvQuipsters);
         tvQuipsters.setText(circle.getMembers().size() + " quipsters");
     }
 

--- a/app/src/main/java/it/quip/android/fragment/CreateCircleFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/CreateCircleFragment.java
@@ -1,0 +1,33 @@
+package it.quip.android.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+
+import it.quip.android.R;
+
+public class CreateCircleFragment extends Fragment {
+
+    private EditText etCircleName;
+
+    public static CreateCircleFragment newInstance() {
+        return new CreateCircleFragment();
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_create_circle, container, false);
+        etCircleName = (EditText) v.findViewById(R.id.et_circle_name);
+        return v;
+    }
+
+    public String getCircleName() {
+        return etCircleName.getText().toString();
+    }
+
+}

--- a/app/src/main/java/it/quip/android/fragment/CreateCircleFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/CreateCircleFragment.java
@@ -22,7 +22,7 @@ public class CreateCircleFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_create_circle, container, false);
-        etCircleName = (EditText) v.findViewById(R.id.et_circle_name);
+        etCircleName = (EditText) v.findViewById(R.id.etCircleName);
         return v;
     }
 

--- a/app/src/main/java/it/quip/android/fragment/InviteFriendsFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/InviteFriendsFragment.java
@@ -43,9 +43,9 @@ public class InviteFriendsFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_invite_friends, container, false);
 
-        etFriendName = (EditText) v.findViewById(R.id.et_friend_name);
+        etFriendName = (EditText) v.findViewById(R.id.etFriendName);
 
-        OverlayListView friendsOverlay = (OverlayListView) v.findViewById(R.id.overlay_friends);
+        OverlayListView friendsOverlay = (OverlayListView) v.findViewById(R.id.overlayFriends);
         friendsOverlay.setAdapter(aFilteredFriends);
         friendsOverlay.setOnItemSelectedListener(new OverlayListView.OnItemSelectedListener() {
             @Override
@@ -54,7 +54,7 @@ public class InviteFriendsFragment extends Fragment {
             }
         });
 
-        ListView lvInvitedFriends = (ListView) v.findViewById(R.id.lv_invited_friends);
+        ListView lvInvitedFriends = (ListView) v.findViewById(R.id.lvInvitedFriends);
         lvInvitedFriends.setAdapter(aInvitedFriends);
 
         setupFriendNameField();

--- a/app/src/main/java/it/quip/android/fragment/InviteFriendsFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/InviteFriendsFragment.java
@@ -1,0 +1,130 @@
+package it.quip.android.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.ListView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import it.quip.android.QuipitApplication;
+import it.quip.android.R;
+import it.quip.android.adapter.UsersArrayAdapter;
+import it.quip.android.model.User;
+import it.quip.android.util.MockUtils;
+import it.quip.android.view.OverlayListView;
+
+public class InviteFriendsFragment extends Fragment {
+
+    private EditText etFriendName;
+
+    private UsersArrayAdapter aFilteredFriends;
+
+    private ArrayList<User> invitedFriends;
+    private UsersArrayAdapter aInvitedFriends;
+
+    public static InviteFriendsFragment newInstance() {
+        return new InviteFriendsFragment();
+    }
+
+    public List<User> getInvitedFriends() {
+        return invitedFriends;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_invite_friends, container, false);
+
+        etFriendName = (EditText) v.findViewById(R.id.et_friend_name);
+
+        OverlayListView friendsOverlay = (OverlayListView) v.findViewById(R.id.overlay_friends);
+        friendsOverlay.setAdapter(aFilteredFriends);
+        friendsOverlay.setOnItemSelectedListener(new OverlayListView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(int position, View view) {
+                inviteFriend(aFilteredFriends.getItem(position));
+            }
+        });
+
+        ListView lvInvitedFriends = (ListView) v.findViewById(R.id.lv_invited_friends);
+        lvInvitedFriends.setAdapter(aInvitedFriends);
+
+        setupFriendNameField();
+
+        return v;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        ArrayList<User> filteredFriends = new ArrayList<>();
+        aFilteredFriends = new UsersArrayAdapter(getContext(), filteredFriends);
+
+        invitedFriends = new ArrayList<>();
+        aInvitedFriends = new UsersArrayAdapter(getContext(), invitedFriends);
+        aInvitedFriends.setOnLongClickListener(new UsersArrayAdapter.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(int position, User user) {
+                aInvitedFriends.remove(user);
+                return true;
+            }
+        });
+    }
+
+    private void inviteFriend(User friend) {
+        aInvitedFriends.add(friend);
+
+        etFriendName.setText("");
+        aFilteredFriends.clear();
+    }
+
+    private void setupFriendNameField() {
+        etFriendName.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                searchFriends(s.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
+    }
+
+    private void searchFriends(String name) {
+        aFilteredFriends.clear();
+
+        for (User friend : MockUtils.getUsers()) {
+            if (!"".equals(name) &&
+                    !myself(friend) &&
+                    friend.getName().toLowerCase().contains(name) &&
+                    !alreadyInvited(friend)) {
+                aFilteredFriends.add(friend);
+            }
+        }
+    }
+
+    private boolean myself(User friend) {
+        return friend.getUid() == QuipitApplication.getCurrentUser().getUid();
+    }
+
+    private boolean alreadyInvited(User friend) {
+        return invitedFriends.contains(friend);
+    }
+
+}

--- a/app/src/main/java/it/quip/android/fragment/NotificationsFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/NotificationsFragment.java
@@ -27,7 +27,7 @@ public class NotificationsFragment extends BaseFragment implements NotificationH
 
     @Override
     public CharSequence getTitle() {
-        return stringRes(R.string.NOTIFICATION_FRAGMENT_TITLE);
+        return stringRes(R.string.title_notifications);
     }
 
 

--- a/app/src/main/java/it/quip/android/fragment/NotificationsFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/NotificationsFragment.java
@@ -77,7 +77,7 @@ public class NotificationsFragment extends BaseFragment implements NotificationH
     @Override
     public void onClickNotificationUser(User selectedUser) {
         // TODO: Sprint 2 hookups
-        Toast.makeText(this.getContext(), selectedUser.getFirstName(), Toast.LENGTH_LONG).show();
+        Toast.makeText(this.getContext(), selectedUser.getName(), Toast.LENGTH_LONG).show();
     }
 
     @Override

--- a/app/src/main/java/it/quip/android/fragment/NotificationsFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/NotificationsFragment.java
@@ -27,7 +27,7 @@ public class NotificationsFragment extends BaseFragment implements NotificationH
 
     @Override
     public CharSequence getTitle() {
-        return stringRes(R.string.title_notifications);
+        return stringRes(R.string.titleNotifications);
     }
 
 

--- a/app/src/main/java/it/quip/android/fragment/ViewCircleFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/ViewCircleFragment.java
@@ -1,0 +1,56 @@
+package it.quip.android.fragment;
+
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import it.quip.android.R;
+import it.quip.android.model.Circle;
+
+public class ViewCircleFragment extends BaseFragment {
+
+    private static final String CIRCLE = "it.quip.android.CIRCLE";
+
+    private Circle circle;
+
+    public static ViewCircleFragment newInstance(Circle circle) {
+        ViewCircleFragment fragment = new ViewCircleFragment();
+        Bundle args = new Bundle();
+        args.putParcelable(CIRCLE, circle);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public CharSequence getTitle() {
+        return circle.getName();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        circle = getArguments().getParcelable(CIRCLE);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_view_circle, container, false);
+        setupFragments();
+        return v;
+    }
+
+    private void setupFragments() {
+        CircleHeaderFragment circleHeader = CircleHeaderFragment.newInstance(circle);
+        // TODO: drop in the fragment for displaying quips
+
+        getActivity().getSupportFragmentManager().beginTransaction()
+                .replace(R.id.fl_header, circleHeader)
+                .commit();
+    }
+
+
+}

--- a/app/src/main/java/it/quip/android/fragment/ViewCircleFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/ViewCircleFragment.java
@@ -48,7 +48,7 @@ public class ViewCircleFragment extends BaseFragment {
         // TODO: drop in the fragment for displaying quips
 
         getActivity().getSupportFragmentManager().beginTransaction()
-                .replace(R.id.fl_header, circleHeader)
+                .replace(R.id.flHeader, circleHeader)
                 .commit();
     }
 

--- a/app/src/main/java/it/quip/android/model/Circle.java
+++ b/app/src/main/java/it/quip/android/model/Circle.java
@@ -14,7 +14,7 @@ public class Circle implements Parcelable {
 
     private long uid;
     private String name;
-    private List<Quip> quips;
+    private List<User> members = new ArrayList<>();
 
     public long getUid() {
         return uid;
@@ -24,8 +24,12 @@ public class Circle implements Parcelable {
         return name;
     }
 
-    public List<Quip> getQuips() {
-        return quips;
+    public List<User> getMembers() {
+        return members;
+    }
+
+    public void addMember(User member) {
+        members.add(member);
     }
 
     public static Circle fromJSON(JSONObject circleJson) {
@@ -34,7 +38,7 @@ public class Circle implements Parcelable {
         try {
             circle.uid = circleJson.getLong("id");
             circle.name = circleJson.getString("name");
-            circle.quips = Quip.fromJSONArray(circleJson.getJSONArray("quips"));
+            circle.members = User.fromJSONArray(circleJson.getJSONArray("members"));
         } catch (JSONException e) {
             e.printStackTrace();
             return null;
@@ -75,7 +79,7 @@ public class Circle implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeLong(this.uid);
         dest.writeString(this.name);
-        dest.writeTypedList(quips);
+        dest.writeTypedList(members);
     }
 
     public Circle() {
@@ -84,7 +88,7 @@ public class Circle implements Parcelable {
     private Circle(Parcel in) {
         this.uid = in.readLong();
         this.name = in.readString();
-        in.readTypedList(quips, Quip.CREATOR);
+        in.readTypedList(members, User.CREATOR);
     }
 
     public static final Parcelable.Creator<Circle> CREATOR = new Parcelable.Creator<Circle>() {

--- a/app/src/main/java/it/quip/android/model/User.java
+++ b/app/src/main/java/it/quip/android/model/User.java
@@ -3,16 +3,20 @@ package it.quip.android.model;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class User implements Parcelable {
 
     private long uid;
     private long facebookId;
-    private String firstName;
-    private String lastName;
+    private String name;
     private String email;
+    private List<Circle> circles = new ArrayList<>();
 
     public long getUid() {
         return uid;
@@ -22,16 +26,30 @@ public class User implements Parcelable {
         return facebookId;
     }
 
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
+    public String getName() {
+        return name;
     }
 
     public String getEmail() {
         return email;
+    }
+
+    public List<Circle> getCircles() {
+        return circles;
+    }
+
+    public Circle getCircle(long circleId) {
+        for (Circle circle : circles) {
+            if (circle.getUid() == circleId) {
+                return circle;
+            }
+        }
+
+        return null;
+    }
+
+    public void addCircle(Circle circle) {
+        circles.add(circle);
     }
 
     public static User fromJSON(JSONObject userJson) {
@@ -39,16 +57,43 @@ public class User implements Parcelable {
         
         try {
             user.uid = userJson.getLong("id");
-            user.facebookId = userJson.getLong("facebook_id");
-            user.firstName = userJson.getString("first_name");
-            user.lastName = userJson.getString("last_name");
+            user.facebookId = userJson.optLong("facebook_id", -1);
+            user.name = userJson.getString("name");
             user.email = userJson.getString("email");
+
+            JSONArray circlesJson = userJson.optJSONArray("circles");
+            if (circlesJson != null) {
+                user.circles = Circle.fromJSONArray(circlesJson);
+            }
         } catch (JSONException e) {
             e.printStackTrace();
             return null;
         }
 
         return user;
+    }
+
+    public static List<User> fromJSONArray(JSONArray circlesJson) {
+        List<User> users = new ArrayList<>();
+
+        for (int i = 0; i < circlesJson.length(); i++) {
+
+            User user;
+            try {
+                JSONObject quipJson = circlesJson.getJSONObject(i);
+                user = User.fromJSON(quipJson);
+            } catch (JSONException e) {
+                e.printStackTrace();
+                continue;
+            }
+
+            if (user != null) {
+                users.add(user);
+            }
+        }
+
+        return users;
+
     }
 
     @Override
@@ -60,8 +105,7 @@ public class User implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeLong(this.uid);
         dest.writeLong(this.facebookId);
-        dest.writeString(this.firstName);
-        dest.writeString(this.lastName);
+        dest.writeString(this.name);
         dest.writeString(this.email);
     }
 
@@ -71,8 +115,7 @@ public class User implements Parcelable {
     private User(Parcel in) {
         this.uid = in.readLong();
         this.facebookId = in.readLong();
-        this.firstName = in.readString();
-        this.lastName = in.readString();
+        this.name = in.readString();
         this.email = in.readString();
     }
 

--- a/app/src/main/java/it/quip/android/util/MockUtils.java
+++ b/app/src/main/java/it/quip/android/util/MockUtils.java
@@ -1,0 +1,74 @@
+package it.quip.android.util;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import it.quip.android.model.Circle;
+import it.quip.android.model.User;
+
+// TODO: remove this class once we have persistence
+public class MockUtils {
+
+    private static final Random generator = new Random();
+
+    private static final List<User> fakeUsers = Arrays.asList(
+            userWithName("Jonathan Como"),
+            userWithName("Dan Buscaglia"),
+            userWithName("Hasham Ali"),
+            userWithName("Tucker Joseph")
+    );
+
+    private static final List<Circle> fakeCircles = Arrays.asList(
+            circleWithNameAndMembers("#thangs", fakeUsers),
+            circleWithNameAndMembers("SF Crew", fakeUsers)
+    );
+
+    public static List<User> getUsers() {
+        return fakeUsers;
+    }
+
+    public static List<Circle> getCircles() {
+        return fakeCircles;
+    }
+
+    public static User userWithName(String name) {
+        long userId = randomId();
+        String userAsJson = String.format(
+                "{\"email\": \"\", \"name\": \"%s\", \"id\": %d}", name, userId);
+
+        return User.fromJSON(jsonFromString(userAsJson));
+    }
+
+    public static Circle circleWithNameAndMembers(String name, List<User> members) {
+        long circleId = randomId();
+        String circleAsJson = String.format(
+                "{\"name\": \"%s\", \"members\": [], \"id\": %d}", name, circleId);
+
+        Circle circle = Circle.fromJSON(jsonFromString(circleAsJson));
+        if (circle != null) {
+            for (User member : members) {
+                circle.addMember(member);
+            }
+        }
+
+        return circle;
+    }
+
+    private static JSONObject jsonFromString(String json) {
+        try {
+            return new JSONObject(json);
+        } catch (JSONException e) {
+            e.printStackTrace();
+            throw new RuntimeException("You dun fucked up");
+        }
+    }
+
+    private static long randomId() {
+        return generator.nextInt(Integer.MAX_VALUE);
+    }
+
+}

--- a/app/src/main/java/it/quip/android/view/OverlayListView.java
+++ b/app/src/main/java/it/quip/android/view/OverlayListView.java
@@ -1,0 +1,115 @@
+package it.quip.android.view;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.database.DataSetObserver;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.ListAdapter;
+
+import it.quip.android.R;
+
+public class OverlayListView extends LinearLayout {
+
+    private static final int DEFAULT_NUM_OVERLAYS = 5;
+
+    private int numOverlays = DEFAULT_NUM_OVERLAYS;
+
+    private View[] overlays;
+    private ListAdapter adapter;
+
+    private OnItemSelectedListener listener;
+
+    public OverlayListView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        readAttributes(context, attrs);
+        initialize();
+    }
+
+    private void readAttributes(Context context, AttributeSet attrs) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(
+                attrs, R.styleable.OverlayListView, 0, 0);
+
+        try {
+            numOverlays = a.getInt(R.styleable.OverlayListView_maxItems, DEFAULT_NUM_OVERLAYS);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    private void initialize() {
+        overlays = new View[numOverlays];
+        setOrientation(VERTICAL);
+        setClickable(true);
+    }
+
+    public void setAdapter(final ListAdapter adapter) {
+        this.adapter = adapter;
+        this.adapter.registerDataSetObserver(new DataSetObserver() {
+            @Override
+            public void onChanged() {
+                update();
+            }
+        });
+    }
+
+    public void setOnItemSelectedListener(OnItemSelectedListener listener) {
+        this.listener = listener;
+    }
+
+    private void update() {
+        clear();
+
+        int numVisibleOverlays = Math.min(this.numOverlays, adapter.getCount());
+        for (int i = 0; i < numVisibleOverlays; i++) {
+            View overlay = getOverlay(i);
+            overlay.setVisibility(VISIBLE);
+        }
+
+        bringToFront();
+    }
+
+    private void clear() {
+        for (View overlay : overlays) {
+            if (overlay != null) {
+                overlay.setVisibility(GONE);
+            }
+        }
+    }
+
+    private View getOverlay(int position) {
+        View overlay = overlays[position];
+        if (overlay != null) {
+            overlay = adapter.getView(position, overlay, this);
+        } else {
+            overlay = initializeOverlay(position);
+            overlays[position] = overlay;
+            addView(overlay);
+        }
+
+        return overlay;
+    }
+
+    private View initializeOverlay(final int position) {
+        View overlay = adapter.getView(position, null, this);
+        overlay.setVisibility(GONE);
+        overlay.setLayoutParams(new LayoutParams(
+                LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        overlay.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (listener != null) {
+                    listener.onItemSelected(position, v);
+                }
+            }
+        });
+
+        return overlay;
+    }
+
+    public interface OnItemSelectedListener {
+        void onItemSelected(int position, View view);
+    }
+
+}

--- a/app/src/main/res/layout/activity_create_circle.xml
+++ b/app/src/main/res/layout/activity_create_circle.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context="it.quip.android.actvitiy.CreateCircleActivity">
 
-    <FrameLayout android:id="@+id/fl_circle_info"
+    <FrameLayout android:id="@+id/flCircleInfo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
 
@@ -16,11 +16,11 @@
         android:layout_height="1dp" />
 
     <TextView
-        android:text="@string/label_members"
+        android:text="@string/labelMembers"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
-    <FrameLayout android:id="@+id/fl_circle_friends"
+    <FrameLayout android:id="@+id/flCircleFriends"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
 

--- a/app/src/main/res/layout/activity_create_circle.xml
+++ b/app/src/main/res/layout/activity_create_circle.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="it.quip.android.actvitiy.CreateCircleActivity">
+
+    <FrameLayout android:id="@+id/fl_circle_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <View
+        android:background="@android:color/darker_gray"
+        android:layout_width="wrap_content"
+        android:layout_height="1dp" />
+
+    <TextView
+        android:text="@string/label_members"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <FrameLayout android:id="@+id/fl_circle_friends"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,7 +5,7 @@
     tools:context=".LoginActivity">
 
     <Button android:id="@+id/btn_login"
-        android:text="@string/login_with_facebook"
+        android:text="@string/loginWithFacebook"
         android:layout_centerInParent="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/activity_quipit_home.xml
+++ b/app/src/main/res/layout/activity_quipit_home.xml
@@ -17,7 +17,7 @@
             android:layout_height="wrap_content" />
 
         <FrameLayout
-            android:id="@+id/fl_content"
+            android:id="@+id/flContent"
             android:layout_below="@id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
@@ -25,7 +25,7 @@
     </RelativeLayout>
 
     <android.support.design.widget.NavigationView
-        android:id="@+id/nv_view"
+        android:id="@+id/nvView"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"

--- a/app/src/main/res/layout/fragment_circle_header.xml
+++ b/app/src/main/res/layout/fragment_circle_header.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:background="@android:color/darker_gray"
+    android:layout_width="match_parent"
+    android:layout_height="180dp">
+
+    <ImageView android:id="@+id/iv_avatar"
+        android:src="@mipmap/ic_launcher"
+        android:layout_centerInParent="true"
+        android:layout_width="60dp"
+        android:layout_height="60dp" />
+
+    <TextView android:id="@+id/tv_name"
+        android:text="#thangs"
+        android:textSize="16sp"
+        android:textColor="@android:color/white"
+        android:gravity="center"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/iv_avatar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView android:id="@+id/tv_quipsters"
+        android:text="4 quipsters"
+        android:textSize="12sp"
+        android:textColor="@android:color/white"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/tv_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_circle_header.xml
+++ b/app/src/main/res/layout/fragment_circle_header.xml
@@ -4,28 +4,28 @@
     android:layout_width="match_parent"
     android:layout_height="180dp">
 
-    <ImageView android:id="@+id/iv_avatar"
+    <ImageView android:id="@+id/ivAvatar"
         android:src="@mipmap/ic_launcher"
         android:layout_centerInParent="true"
         android:layout_width="60dp"
         android:layout_height="60dp" />
 
-    <TextView android:id="@+id/tv_name"
+    <TextView android:id="@+id/tvName"
         android:text="#thangs"
         android:textSize="16sp"
         android:textColor="@android:color/white"
         android:gravity="center"
         android:layout_centerHorizontal="true"
-        android:layout_below="@id/iv_avatar"
+        android:layout_below="@id/ivAvatar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
-    <TextView android:id="@+id/tv_quipsters"
+    <TextView android:id="@+id/tvQuipsters"
         android:text="4 quipsters"
         android:textSize="12sp"
         android:textColor="@android:color/white"
         android:layout_centerHorizontal="true"
-        android:layout_below="@id/tv_name"
+        android:layout_below="@id/tvName"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/fragment_create_circle.xml
+++ b/app/src/main/res/layout/fragment_create_circle.xml
@@ -4,8 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <EditText android:id="@+id/et_circle_name"
-        android:hint="@string/hint_circle_name"
+    <EditText android:id="@+id/etCircleName"
+        android:hint="@string/hintCircleName"
         android:singleLine="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/fragment_create_circle.xml
+++ b/app/src/main/res/layout/fragment_create_circle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText android:id="@+id/et_circle_name"
+        android:hint="@string/hint_circle_name"
+        android:singleLine="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_invite_friends.xml
+++ b/app/src/main/res/layout/fragment_invite_friends.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText android:id="@+id/et_friend_name"
+        android:hint="@string/hint_friend_name"
+        android:singleLine="true"
+        android:layout_alignParentTop="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <it.quip.android.view.OverlayListView
+        android:id="@+id/overlay_friends"
+        android:background="@android:color/white"
+        custom:maxItems="5"
+        android:layout_marginLeft="30dp"
+        android:layout_marginStart="30dp"
+        android:layout_marginRight="30dp"
+        android:layout_marginEnd="30dp"
+        android:layout_below="@id/et_friend_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <ListView android:id="@+id/lv_invited_friends"
+        android:layout_alignParentBottom="true"
+        android:layout_below="@id/et_friend_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_invite_friends.xml
+++ b/app/src/main/res/layout/fragment_invite_friends.xml
@@ -5,28 +5,28 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <EditText android:id="@+id/et_friend_name"
-        android:hint="@string/hint_friend_name"
+    <EditText android:id="@+id/etFriendName"
+        android:hint="@string/hintFriendName"
         android:singleLine="true"
         android:layout_alignParentTop="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <it.quip.android.view.OverlayListView
-        android:id="@+id/overlay_friends"
+        android:id="@+id/overlayFriends"
         android:background="@android:color/white"
         custom:maxItems="5"
         android:layout_marginLeft="30dp"
         android:layout_marginStart="30dp"
         android:layout_marginRight="30dp"
         android:layout_marginEnd="30dp"
-        android:layout_below="@id/et_friend_name"
+        android:layout_below="@id/etFriendName"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <ListView android:id="@+id/lv_invited_friends"
+    <ListView android:id="@+id/lvInvitedFriends"
         android:layout_alignParentBottom="true"
-        android:layout_below="@id/et_friend_name"
+        android:layout_below="@id/etFriendName"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/fragment_view_circle.xml
+++ b/app/src/main/res/layout/fragment_view_circle.xml
@@ -3,12 +3,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout android:id="@+id/fl_header"
+    <FrameLayout android:id="@+id/flHeader"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <FrameLayout android:id="@+id/fl_quips"
-        android:layout_below="@id/fl_header"
+    <FrameLayout android:id="@+id/flQuips"
+        android:layout_below="@id/flHeader"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/fragment_view_circle.xml
+++ b/app/src/main/res/layout/fragment_view_circle.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout android:id="@+id/fl_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <FrameLayout android:id="@+id/fl_quips"
+        android:layout_below="@id/fl_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/item_user.xml
+++ b/app/src/main/res/layout/item_user.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView android:id="@+id/tv_name"
+    <TextView android:id="@+id/tvName"
         android:text="Jonathan Como"
         android:textSize="16sp"
         android:textColor="@android:color/black"

--- a/app/src/main/res/layout/item_user.xml
+++ b/app/src/main/res/layout/item_user.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView android:id="@+id/tv_name"
+        android:text="Jonathan Como"
+        android:textSize="16sp"
+        android:textColor="@android:color/black"
+        android:padding="10dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -3,14 +3,14 @@
 
     <group android:checkableBehavior="single">
 
-        <item android:id="@+id/nav_notifications"
+        <item android:id="@+id/navNotifications"
             android:icon="@drawable/ic_notification"
             android:title="@string/notifications" />
 
-        <item android:id="@+id/nav_circles"
+        <item android:id="@+id/navCircles"
             android:title="@string/circles">
 
-            <menu android:id="@+id/menu_circles">
+            <menu android:id="@+id/menuCircles">
                 <item android:title="#somethangs" />
                 <item android:title="SF crew" />
             </menu>

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -10,7 +10,7 @@
         <item android:id="@+id/nav_circles"
             android:title="@string/circles">
 
-            <menu>
+            <menu android:id="@+id/menu_circles">
                 <item android:title="#somethangs" />
                 <item android:title="SF crew" />
             </menu>

--- a/app/src/main/res/menu/menu_create_circle.xml
+++ b/app/src/main/res/menu/menu_create_circle.xml
@@ -2,8 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:id="@+id/mi_create_circle"
-        android:title="@string/action_create"
+    <item android:id="@+id/miCreateCircle"
+        android:title="@string/actionCreate"
         android:orderInCategory="5"
         app:showAsAction="ifRoom"/>
 

--- a/app/src/main/res/menu/menu_create_circle.xml
+++ b/app/src/main/res/menu/menu_create_circle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/mi_create_circle"
+        android:title="@string/action_create"
+        android:orderInCategory="5"
+        app:showAsAction="ifRoom"/>
+
+</menu>

--- a/app/src/main/res/menu/menu_login.xml
+++ b/app/src/main/res/menu/menu_login.xml
@@ -1,6 +1,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools" tools:context=".LoginActivity">
-    <item android:id="@+id/action_settings" android:title="@string/action_settings"
+    <item android:id="@+id/actionSettings" android:title="@string/actionSettings"
         android:orderInCategory="100" app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/menu_login.xml
+++ b/app/src/main/res/menu/menu_login.xml
@@ -1,6 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools" tools:context=".LoginActivity">
-    <item android:id="@+id/actionSettings" android:title="@string/actionSettings"
-        android:orderInCategory="100" app:showAsAction="never" />
-</menu>

--- a/app/src/main/res/menu/menu_quipit_home.xml
+++ b/app/src/main/res/menu/menu_quipit_home.xml
@@ -4,14 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".LoginActivity">
 
-    <item android:id="@+id/mi_new_quip"
-        android:title="@string/action_new_quip"
+    <item android:id="@+id/miNewQuip"
+        android:title="@string/actionNewQuip"
         android:icon="@drawable/ic_quip_new"
         android:orderInCategory="5"
         app:showAsAction="ifRoom" />
 
-    <item android:id="@+id/mi_new_circle"
-        android:title="@string/action_new_circle"
+    <item android:id="@+id/miNewCircle"
+        android:title="@string/actionNewCircle"
         android:icon="@drawable/ic_circle_new"
         android:orderInCategory="10"
         app:showAsAction="ifRoom" />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="OverlayListView">
+        <attr name="maxItems" format="integer" />
+    </declare-styleable>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,19 +1,24 @@
 <resources>
     <string name="app_name">QuipIt</string>
 
+    <string name="title_create_circle">New Circle</string>
+    <string name="title_notifications">Notifications</string>
+
     <string name="action_settings">Settings</string>
+    <string name="action_new_quip">New Quip</string>
+    <string name="action_new_circle">New Circle</string>
+    <string name="action_create">Create</string>
 
     <string name="login_with_facebook">Login with Facebook</string>
 
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
 
-    <string name="action_new_quip">New Quip</string>
-    <string name="action_new_circle">New Circle</string>
     <string name="notifications">Notifications</string>
     <string name="circles">Circles</string>
 
+    <string name="hint_circle_name">Circle Name</string>
+    <string name="hint_friend_name">Search for friends</string>
 
-    <!-- Fragment Titles -->
-    <string name="NOTIFICATION_FRAGMENT_TITLE">Notifications</string>
+    <string name="label_members">Members</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,24 +1,24 @@
 <resources>
-    <string name="app_name">QuipIt</string>
+    <string name="appName">QuipIt</string>
 
-    <string name="title_create_circle">New Circle</string>
-    <string name="title_notifications">Notifications</string>
+    <string name="titleCreateCircle">New Circle</string>
+    <string name="titleNotifications">Notifications</string>
 
-    <string name="action_settings">Settings</string>
-    <string name="action_new_quip">New Quip</string>
-    <string name="action_new_circle">New Circle</string>
-    <string name="action_create">Create</string>
+    <string name="actionSettings">Settings</string>
+    <string name="actionNewQuip">New Quip</string>
+    <string name="actionNewCircle">New Circle</string>
+    <string name="actionCreate">Create</string>
 
-    <string name="login_with_facebook">Login with Facebook</string>
+    <string name="loginWithFacebook">Login with Facebook</string>
 
-    <string name="drawer_open">Open navigation drawer</string>
-    <string name="drawer_close">Close navigation drawer</string>
+    <string name="drawerOpen">Open navigation drawer</string>
+    <string name="drawerClose">Close navigation drawer</string>
 
     <string name="notifications">Notifications</string>
     <string name="circles">Circles</string>
 
-    <string name="hint_circle_name">Circle Name</string>
-    <string name="hint_friend_name">Search for friends</string>
+    <string name="hintCircleName">Circle Name</string>
+    <string name="hintFriendName">Search for friends</string>
 
-    <string name="label_members">Members</string>
+    <string name="labelMembers">Members</string>
 </resources>


### PR DESCRIPTION
### Overview

At a high level, this PR covers the circle creation flow. Editing is not covered with these changes. However, a user can create a new circle and invite friends. It also adds dynamic functionality to the sidebar by updating the sidebar to show all of the circles that the user belongs to
### Technical changes
- `CreateCircleActivity` is where the logic for creating the circle lives. This activity houses two fragments, `CreateCircleFragment` (which right now only handles the name, but will most likely handle more in the future) and `InviteFriendsFragment` (which is where the user can invite friends and see them in a list before creating the circle)
- Adds `MockUtils` which has methods for adding users/circles and getting fake data **using only the public APIs we've provided**. This will make it easy to pull it out later and put in the real persistence since we haven't coupled mocking with the real classes.
- Adds a very basic `UsersArrayAdapter` that right now only displays the name of the user, but we can add the profile image, etc when sprucing up the design
- The `OverlayListView` is a non-scrollable list view that is meant to display results as the adapter updates, adding and removing overlay views as necessary. It operates the same way as a list view (set the adapter, set the on item click listener) and can accept the `maxItems` attribute in XML, which will put a limit on the amount of overlay views to be displayed
### Notes

Only the header fragment for the circles is done. I will plug in the quips view once Hasham's PR is merged
### Walkthrough

![](http://i.giphy.com/l41m3rSFPUrm8NxTO.gif)
### Reviewers
- [ ] @dbuscaglia 
- [x] @hashamali 
