### PR TITLE
View quips in circle

### DIFF
--- a/app/src/main/java/it/quip/android/activity/QuipitHomeActivity.java
+++ b/app/src/main/java/it/quip/android/activity/QuipitHomeActivity.java
@@ -26,8 +26,8 @@ import java.util.List;
 
 import it.quip.android.QuipitApplication;
 import it.quip.android.R;
+import it.quip.android.fragment.HomeFeedFragment;
 import it.quip.android.fragment.NotificationsFragment;
-import it.quip.android.fragment.QuipFeedFragment;
 import it.quip.android.fragment.ViewCircleFragment;
 import it.quip.android.listener.TagClickListener;
 import it.quip.android.model.Circle;
@@ -174,7 +174,7 @@ public class QuipitHomeActivity extends AppCompatActivity implements TagClickLis
 
     private void displayDefaultQuipStream() {
         // TODO: We shouldn't be creating a new fragment each time. We should manage these
-        prepareFragment(new QuipFeedFragment(), false).commit();
+        prepareFragment(new HomeFeedFragment(), false).commit();
     }
 
     @Override

--- a/app/src/main/java/it/quip/android/adapter/QuipsAdapter.java
+++ b/app/src/main/java/it/quip/android/adapter/QuipsAdapter.java
@@ -17,6 +17,7 @@ import it.quip.android.R;
 import it.quip.android.fragment.QuipFeedFragment;
 import it.quip.android.graphics.CircleTransformation;
 import it.quip.android.model.Quip;
+import it.quip.android.model.User;
 
 public class QuipsAdapter extends RecyclerView.Adapter<QuipsViewHolder> {
 
@@ -69,7 +70,16 @@ public class QuipsAdapter extends RecyclerView.Adapter<QuipsViewHolder> {
         setupProfile(quip, viewHolder);
         viewHolder.mTvQuipTimestamp.setText("2d");
         viewHolder.mTvQuipBody.setText(quip.getText());
-        viewHolder.mTvQuipSourceUserName.setText(quip.getSource().getName());
+
+        String sourceName;
+        User source = quip.getSource();
+        if (null == source) {
+            sourceName = "anon";
+        } else {
+            sourceName = source.getName();
+        }
+
+        viewHolder.mTvQuipSourceUserName.setText(sourceName);
     }
 
 }

--- a/app/src/main/java/it/quip/android/fragment/CircleFeedFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/CircleFeedFragment.java
@@ -1,0 +1,53 @@
+package it.quip.android.fragment;
+
+import android.os.Bundle;
+
+import com.parse.FindCallback;
+import com.parse.ParseException;
+import com.parse.ParseQuery;
+
+import java.util.List;
+
+import it.quip.android.model.Circle;
+import it.quip.android.model.Quip;
+
+public class CircleFeedFragment extends QuipFeedFragment {
+
+    private static final String CIRCLE = "it.quip.android.CIRCLE";
+
+    private Circle mCircle;
+
+    public static CircleFeedFragment newInstance(Circle circle) {
+        CircleFeedFragment fragment = new CircleFeedFragment();
+        Bundle args = new Bundle();
+        args.putParcelable(CIRCLE, circle);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mCircle = getArguments().getParcelable(CIRCLE);
+    }
+
+    @Override
+    public void loadInitialQuips() {
+        new ParseQuery<>(Quip.class)
+                .whereEqualTo(Quip.CIRCLE, mCircle)
+                .addDescendingOrder("created_at")
+                .findInBackground(new FindCallback<Quip>() {
+                    @Override
+                    public void done(List<Quip> quips, ParseException e) {
+                        setQuips(quips);
+                        hideProgressIndicators();
+                    }
+                });
+    }
+
+    @Override
+    public void loadMoreQuips(int page) {
+
+    }
+
+}

--- a/app/src/main/java/it/quip/android/fragment/HomeFeedFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/HomeFeedFragment.java
@@ -1,0 +1,32 @@
+package it.quip.android.fragment;
+
+import com.parse.FindCallback;
+import com.parse.ParseException;
+import com.parse.ParseQuery;
+
+import java.util.List;
+
+import it.quip.android.model.Quip;
+
+public class HomeFeedFragment extends QuipFeedFragment {
+
+    @Override
+    public void loadInitialQuips() {
+        // TODO: should be scoped to users circles/friends
+        new ParseQuery<>(Quip.class)
+                .addDescendingOrder("created_at")
+                .findInBackground(new FindCallback<Quip>() {
+                    @Override
+                    public void done(List<Quip> quips, ParseException e) {
+                        setQuips(quips);
+                        hideProgressIndicators();
+                    }
+                });
+    }
+
+    @Override
+    public void loadMoreQuips(int page) {
+
+    }
+
+}

--- a/app/src/main/java/it/quip/android/fragment/QuipFeedFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/QuipFeedFragment.java
@@ -16,26 +16,52 @@ import it.quip.android.adapter.QuipsAdapter;
 import it.quip.android.listener.EndlessScrollListener;
 import it.quip.android.model.Quip;
 
-public class QuipFeedFragment extends BaseFragment {
+public abstract class QuipFeedFragment extends BaseFragment {
 
     @Override
     public CharSequence getTitle() {
         return "Quips";
     }
 
-    protected List<Quip> mQuips;
-    protected QuipsAdapter mQuipsAdapter;
+    private List<Quip> mQuips;
+    private QuipsAdapter mQuipsAdapter;
 
     private SwipeRefreshLayout mSrlFeed;
     private RecyclerView mRvFeed;
     private LinearLayoutManager mLlManager;
 
+    public abstract void loadInitialQuips();
+    public abstract void loadMoreQuips(int page);
+
+    public void addQuip(Quip quip) {
+        mQuips.add(quip);
+        mQuipsAdapter.notifyDataSetChanged();
+    }
+
+    public void addQuips(List<Quip> quips) {
+        mQuips.addAll(quips);
+        mQuipsAdapter.notifyDataSetChanged();
+    }
+
+    public void setQuips(List<Quip> quips) {
+        mQuips.clear();
+        addQuips(quips);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mQuips = new ArrayList<>();
+        mQuipsAdapter = new QuipsAdapter(mQuips, this);
+
+        loadInitialQuips();
+    }
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_feed, container, false);
         setupViewDependencies(view);
-        populateFeed(false);
-
         return view;
     }
 
@@ -44,38 +70,30 @@ public class QuipFeedFragment extends BaseFragment {
         mSrlFeed.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
-                populateFeed(false);
+                loadInitialQuips();
             }
         });
 
-        mRvFeed = (RecyclerView) view.findViewById(R.id.rv_feed);
-        mQuips = new ArrayList<Quip>();
-        mQuipsAdapter = new QuipsAdapter(mQuips, this);
-        mRvFeed.setAdapter(mQuipsAdapter);
-
         mLlManager = new LinearLayoutManager(getContext());
+
+        mRvFeed = (RecyclerView) view.findViewById(R.id.rv_feed);
+        mRvFeed.setAdapter(mQuipsAdapter);
         mRvFeed.setLayoutManager(mLlManager);
         mRvFeed.addOnScrollListener(new EndlessScrollListener(mLlManager) {
-
             @Override
             public void onLoadMore(int currentPage) {
-                populateFeed(true);
+                loadMoreQuips(currentPage);
             }
-
         });
     }
 
-    private void populateFeed(final boolean additional) {
-        if (mQuips.size() < 20) {
-            if (!additional) {
-                mQuips.clear();
-            }
+    public void showProcessIndicators() {
+        // This will show the network indicator
+    }
 
-            //mQuips.addAll(MockUtils.getQuips());
-            mQuipsAdapter.notifyDataSetChanged();
-        }
-
+    public void hideProgressIndicators() {
         mSrlFeed.setRefreshing(false);
+        // TODO: Hide the network indicator here
     }
 
 }

--- a/app/src/main/java/it/quip/android/fragment/ViewCircleFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/ViewCircleFragment.java
@@ -45,10 +45,11 @@ public class ViewCircleFragment extends BaseFragment {
 
     private void setupFragments() {
         CircleHeaderFragment circleHeader = CircleHeaderFragment.newInstance(circle);
-        // TODO: drop in the fragment for displaying quips
+        CircleFeedFragment circleFeed = CircleFeedFragment.newInstance(circle);
 
         getActivity().getSupportFragmentManager().beginTransaction()
                 .replace(R.id.fl_header, circleHeader)
+                .replace(R.id.fl_quips, circleFeed)
                 .commit();
     }
 

--- a/app/src/main/java/it/quip/android/model/BaseParseObject.java
+++ b/app/src/main/java/it/quip/android/model/BaseParseObject.java
@@ -1,5 +1,6 @@
 package it.quip.android.model;
 
+import com.parse.ParseException;
 import com.parse.ParseObject;
 
 
@@ -8,6 +9,21 @@ public class BaseParseObject extends ParseObject {
     protected void safePut(String key, Object value) {
         if (value != null) {
             this.put(key, value);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T extends ParseObject> T getRelated(String key) {
+        ParseObject object = getParseObject(key);
+        if (null == object) {
+            return null;
+        }
+
+        try {
+            return (T) object.fetchIfNeeded();
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return null;
         }
     }
 

--- a/app/src/main/java/it/quip/android/model/Quip.java
+++ b/app/src/main/java/it/quip/android/model/Quip.java
@@ -15,12 +15,12 @@ import it.quip.android.QuipitApplication;
 @ParseClassName("Quip")
 public class Quip extends BaseParseObject implements Parcelable {
 
-    private static final String TEXT = "text";
-    private static final String AUTHOR = "author";
-    private static final String SOURCE = "source";
-    private static final String CIRCLE = "circle";
-    private static final String TIMESTAMP = "timestamp";
-    private static final String IMAGE_URL = "image_url";
+    public static final String TEXT = "text";
+    public static final String AUTHOR = "author";
+    public static final String SOURCE = "source";
+    public static final String CIRCLE = "circle";
+    public static final String TIMESTAMP = "timestamp";
+    public static final String IMAGE_URL = "image_url";
 
     private String text;
     private User author;
@@ -30,27 +30,27 @@ public class Quip extends BaseParseObject implements Parcelable {
     private String imageUrl;
 
     public String getText() {
-        return text;
+        return getString(TEXT);
     }
 
     public User getAuthor() {
-        return author;
+        return getRelated(AUTHOR);
     }
 
     public User getSource() {
-        return source;
+        return getRelated(SOURCE);
     }
 
     public Circle getCircle() {
-        return circle;
+        return getRelated(CIRCLE);
     }
 
     public long getTimestamp() {
-        return timestamp;
+        return getLong(TIMESTAMP);
     }
 
     public String getImageUrl() {
-        return imageUrl;
+        return getString(IMAGE_URL);
     }
 
     public void setText(String text) {

--- a/app/src/main/res/layout/activity_quipit_home.xml
+++ b/app/src/main/res/layout/activity_quipit_home.xml
@@ -25,6 +25,7 @@
             android:layout_below="@+id/toolbar"
             layout="@layout/notification_toast_bar"
             ></include>
+
         <FrameLayout
             android:id="@+id/fl_content"
             android:layout_below="@id/sub_tool_bar"


### PR DESCRIPTION
Makes the original quip feed fragment abstract.
It exposes two methods: loadInitialQuips and loadMoreQuips.

Adds convenience methods to fetch related parse objects.
