### PR TITLE
Broadcast receiver for notifications.

### DIFF
--- a/app/src/main/java/it/quip/android/activity/QuipitHomeActivity.java
+++ b/app/src/main/java/it/quip/android/activity/QuipitHomeActivity.java
@@ -76,7 +76,7 @@ public class QuipitHomeActivity extends AppCompatActivity implements TagClickLis
             String action = intent.getAction();
 
             if (Notification.NOTIFICATION_RECEIVED_ACTION.equals(action)) {
-                Notification notification = (Notification) intent.getExtras().get("new_notification");
+                Notification notification = (Notification) intent.getExtras().get(Notification.MARSHALL_INTENT_KEY);
                 onNotificationToast(notification);
             }
         }

--- a/app/src/main/java/it/quip/android/activity/QuipitHomeActivity.java
+++ b/app/src/main/java/it/quip/android/activity/QuipitHomeActivity.java
@@ -3,6 +3,8 @@ package it.quip.android.activity;
 import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.animation.AnimatorListenerAdapter;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
@@ -10,6 +12,7 @@ import android.os.Bundle;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
@@ -19,6 +22,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
@@ -47,6 +51,7 @@ public class QuipitHomeActivity extends AppCompatActivity implements TagClickLis
     private ActionBarDrawerToggle mDrawerToggle;
     private NavigationView mNavDrawer;
     private RelativeLayout mNotificationBar;
+    private TextView mNotificationBarNotificationText;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -60,9 +65,29 @@ public class QuipitHomeActivity extends AppCompatActivity implements TagClickLis
     }
 
     private void registerBroadcastReceivers() {
-        // setting up for new notification
-        //IntentFilter filter = new IntentFilter(CONNECTIVITY_CHANGE_ACTION);
-        //this.registerReceiver(mChangeConnectionReceiver, filter);
+        LocalBroadcastManager.getInstance(this).registerReceiver(mNotificationReceiver,
+                new IntentFilter(Notification.NOTIFICATION_RECEIVED_ACTION));
+    }
+
+    private final BroadcastReceiver mNotificationReceiver = new BroadcastReceiver() {
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+
+            if (Notification.NOTIFICATION_RECEIVED_ACTION.equals(action)) {
+                Notification notification = (Notification) intent.getExtras().get("new_notification");
+                onNotificationToast(notification);
+            }
+        }
+    };
+
+    @Override
+    protected void onDestroy() {
+        if(mNotificationReceiver != null) {
+            LocalBroadcastManager.getInstance(this).unregisterReceiver(mNotificationReceiver);
+        }
+        super.onDestroy();
     }
 
 
@@ -124,6 +149,7 @@ public class QuipitHomeActivity extends AppCompatActivity implements TagClickLis
 
     private void setupNotificationToastBar() {
         mNotificationBar = (RelativeLayout) findViewById(R.id.toolbar_notification_toast_bard);
+        mNotificationBarNotificationText = (TextView) findViewById(R.id.toolbaNotificationText);
     }
 
     private void selectDrawerItem(MenuItem menuItem) {
@@ -247,6 +273,7 @@ public class QuipitHomeActivity extends AppCompatActivity implements TagClickLis
 
     public void onNotificationToast(Notification notification) {
         Animator anim = AnimatorInflater.loadAnimator(this, R.animator.notification);
+        mNotificationBarNotificationText.setText(notification.getText());
         anim.setTarget(mNotificationBar);
         mNotificationBar.setVisibility(View.VISIBLE);
         mNotificationBar.setAlpha(1);

--- a/app/src/main/java/it/quip/android/model/Notification.java
+++ b/app/src/main/java/it/quip/android/model/Notification.java
@@ -28,6 +28,9 @@ import it.quip.android.util.TimeUtils;
 @ParseClassName("Notification")
 public class Notification extends BaseParseObject implements Parcelable {
 
+    public static final int FLAG_NOTIFICATION_RECEIVED = 45678;
+    public static final String NOTIFICATION_RECEIVED_ACTION = "com.notifications.ReceivedQuipNotification";
+
     public static final int STANDARD_NOTIFICATION = 0;
     public static final String PUSH_TEXT_BODY_KEY = "text_body";
     public static final String PUSH_SENDER_ID = "sender_uid";

--- a/app/src/main/java/it/quip/android/model/Notification.java
+++ b/app/src/main/java/it/quip/android/model/Notification.java
@@ -30,6 +30,8 @@ public class Notification extends BaseParseObject implements Parcelable {
 
     public static final int FLAG_NOTIFICATION_RECEIVED = 45678;
     public static final String NOTIFICATION_RECEIVED_ACTION = "com.notifications.ReceivedQuipNotification";
+    public static final String MARSHALL_INTENT_KEY = "new_notification";
+
 
     public static final int STANDARD_NOTIFICATION = 0;
     public static final String PUSH_TEXT_BODY_KEY = "text_body";

--- a/app/src/main/java/it/quip/android/network/NotificationReceiver.java
+++ b/app/src/main/java/it/quip/android/network/NotificationReceiver.java
@@ -56,8 +56,9 @@ public class NotificationReceiver extends ParsePushBroadcastReceiver {
                 if (json.has(Notification.PUSH_TEXT_BODY_KEY)) {
                     Notification notification = Notification.fromJson(json);
                     if ((notification != null) && (!notification.getSenderUid().equals(QuipitApplication.getCurrentUser().getObjectId()))) {
-                        triggerBroadcastToActivity(context, notification);
+                        //triggerBroadcastToActivity(context, notification);
                     }
+                    triggerBroadcastToActivity(context, notification);
                 } else {
                     // This is a global push, just use alert
                     Notification notification = new Notification();
@@ -76,8 +77,9 @@ public class NotificationReceiver extends ParsePushBroadcastReceiver {
     }
 
     private void triggerBroadcastToActivity(Context context, Notification notification) {
-        Intent pupInt = new Intent(context, QuipitHomeActivity.class);
-
+        Intent pupInt = new Intent(Notification.NOTIFICATION_RECEIVED_ACTION);
+        pupInt.setFlags(Notification.FLAG_NOTIFICATION_RECEIVED);
+        pupInt.setAction(Notification.NOTIFICATION_RECEIVED_ACTION);
         pupInt.putExtra("new_notification", notification);
         LocalBroadcastManager.getInstance(context).sendBroadcast(pupInt);
     }

--- a/app/src/main/java/it/quip/android/network/NotificationReceiver.java
+++ b/app/src/main/java/it/quip/android/network/NotificationReceiver.java
@@ -80,7 +80,7 @@ public class NotificationReceiver extends ParsePushBroadcastReceiver {
         Intent pupInt = new Intent(Notification.NOTIFICATION_RECEIVED_ACTION);
         pupInt.setFlags(Notification.FLAG_NOTIFICATION_RECEIVED);
         pupInt.setAction(Notification.NOTIFICATION_RECEIVED_ACTION);
-        pupInt.putExtra("new_notification", notification);
+        pupInt.putExtra(Notification.MARSHALL_INTENT_KEY, notification);
         LocalBroadcastManager.getInstance(context).sendBroadcast(pupInt);
     }
 


### PR DESCRIPTION
## Overview

Notifcations are now relayed and toasted in real time and support images and styles
## Technical Changes

LocalBraodCastManager is used in the home activity and notification receiver to marshall the notification from service to activity via an intent.
The overlay fade toast is then displayed at the top to be styled in the polish week

@hashamali @jcomo 
