### PR TITLE
Fix them timestamps

### DIFF
--- a/app/src/main/java/it/quip/android/activity/CreateQuipActivity.java
+++ b/app/src/main/java/it/quip/android/activity/CreateQuipActivity.java
@@ -16,7 +16,6 @@ import it.quip.android.fragment.QuipSelectFragment;
 import it.quip.android.model.Circle;
 import it.quip.android.model.Quip;
 import it.quip.android.model.User;
-import it.quip.android.util.TimeUtils;
 
 public class CreateQuipActivity
         extends AppCompatActivity
@@ -57,18 +56,15 @@ public class CreateQuipActivity
     private void onPostQuip() {
         if (mQuip != null) {
             List<Circle> circles = mQuipSelectFragment.getSelected();
-            long timestamp = TimeUtils.currentTimestampInS();
 
             // TODO: Figure out how to add a "Share with all friends" option rather than not selecting any circles...
             if (circles.size() > 0) {
                 for (Circle circle : circles) {
                     Quip quip = new Quip(mQuip);
                     quip.setCircle(circle);
-                    quip.setTimestamp(timestamp);
                     quip.saveInternal();
                 }
             } else {
-                mQuip.setTimestamp(timestamp);
                 mQuip.saveInternal();
             }
 

--- a/app/src/main/java/it/quip/android/adapter/QuipsAdapter.java
+++ b/app/src/main/java/it/quip/android/adapter/QuipsAdapter.java
@@ -18,6 +18,7 @@ import it.quip.android.fragment.QuipFeedFragment;
 import it.quip.android.graphics.CircleTransformation;
 import it.quip.android.model.Quip;
 import it.quip.android.model.User;
+import it.quip.android.util.FormatUtils;
 
 public class QuipsAdapter extends RecyclerView.Adapter<QuipsViewHolder> {
 
@@ -68,7 +69,7 @@ public class QuipsAdapter extends RecyclerView.Adapter<QuipsViewHolder> {
 
     private void setupViews(Quip quip, QuipsViewHolder viewHolder) {
         setupProfile(quip, viewHolder);
-        viewHolder.mTvQuipTimestamp.setText("2d");
+        viewHolder.mTvQuipTimestamp.setText(FormatUtils.getRelativeTimeAgo(quip.getTimestamp()));
         viewHolder.mTvQuipBody.setText(quip.getText());
 
         String sourceName;

--- a/app/src/main/java/it/quip/android/fragment/CircleFeedFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/CircleFeedFragment.java
@@ -35,7 +35,7 @@ public class CircleFeedFragment extends QuipFeedFragment {
     public void loadInitialQuips() {
         new ParseQuery<>(Quip.class)
                 .whereEqualTo(Quip.CIRCLE, mCircle)
-                .addDescendingOrder("created_at")
+                .addDescendingOrder("createdAt")
                 .findInBackground(new FindCallback<Quip>() {
                     @Override
                     public void done(List<Quip> quips, ParseException e) {

--- a/app/src/main/java/it/quip/android/fragment/HomeFeedFragment.java
+++ b/app/src/main/java/it/quip/android/fragment/HomeFeedFragment.java
@@ -14,7 +14,7 @@ public class HomeFeedFragment extends QuipFeedFragment {
     public void loadInitialQuips() {
         // TODO: should be scoped to users circles/friends
         new ParseQuery<>(Quip.class)
-                .addDescendingOrder("created_at")
+                .addDescendingOrder("createdAt")
                 .findInBackground(new FindCallback<Quip>() {
                     @Override
                     public void done(List<Quip> quips, ParseException e) {

--- a/app/src/main/java/it/quip/android/model/BaseParseObject.java
+++ b/app/src/main/java/it/quip/android/model/BaseParseObject.java
@@ -4,8 +4,13 @@ import com.parse.ParseException;
 import com.parse.ParseFile;
 import com.parse.ParseObject;
 
+import java.util.Date;
+
 
 public class BaseParseObject extends ParseObject {
+
+    public static final String CREATED_AT = "createdAt";
+    public static final String UPDATED_AT = "updatedAt";
 
     protected void safePut(String key, Object value) {
         if (value != null) {
@@ -20,6 +25,15 @@ public class BaseParseObject extends ParseObject {
         } else {
             return file.getUrl();
         }
+    }
+
+    protected long getTimestamp() {
+        Date created = getCreatedAt();
+        if (null == created) {
+            created = new Date();
+        }
+
+        return created.getTime();
     }
 
     @SuppressWarnings("unchecked")

--- a/app/src/main/java/it/quip/android/model/Quip.java
+++ b/app/src/main/java/it/quip/android/model/Quip.java
@@ -19,14 +19,12 @@ public class Quip extends BaseParseObject implements Parcelable {
     public static final String AUTHOR = "author";
     public static final String SOURCE = "source";
     public static final String CIRCLE = "circle";
-    public static final String TIMESTAMP = "timestamp";
     public static final String IMAGE_URL = "image_url";
 
     private String text;
     private User author;
     private User source;
     private Circle circle;
-    private long timestamp;
     private String imageUrl;
 
     public String getText() {
@@ -44,11 +42,7 @@ public class Quip extends BaseParseObject implements Parcelable {
     public Circle getCircle() {
         return getRelated(CIRCLE);
     }
-
-    public long getTimestamp() {
-        return getLong(TIMESTAMP);
-    }
-
+    
     public String getImageUrl() {
         return getString(IMAGE_URL);
     }
@@ -73,11 +67,6 @@ public class Quip extends BaseParseObject implements Parcelable {
         this.safePut(CIRCLE, circle);
     }
 
-    public void setTimestamp(Long timestamp) {
-        this.timestamp = timestamp;
-        this.safePut(TIMESTAMP, timestamp);
-    }
-
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
         this.safePut(IMAGE_URL, imageUrl);
@@ -94,7 +83,6 @@ public class Quip extends BaseParseObject implements Parcelable {
         dest.writeParcelable(this.author, flags);
         dest.writeParcelable(this.source, flags);
         dest.writeParcelable(this.circle, flags);
-        dest.writeLong(this.timestamp);
         dest.writeString(this.imageUrl);
     }
 
@@ -107,7 +95,6 @@ public class Quip extends BaseParseObject implements Parcelable {
         this.setAuthor(clone.getAuthor());
         this.setSource(clone.getSource());
         this.setCircle(clone.getCircle());
-        this.setTimestamp(clone.getTimestamp());
         this.setImageUrl(clone.getImageUrl());
     }
 
@@ -116,7 +103,6 @@ public class Quip extends BaseParseObject implements Parcelable {
         this.setAuthor(author);
         this.setSource(source);
         this.setCircle(circle);
-        this.setTimestamp(timestamp);
         this.setImageUrl(imageUrl);
     }
 
@@ -125,7 +111,6 @@ public class Quip extends BaseParseObject implements Parcelable {
         this.setAuthor((User) in.readParcelable(User.class.getClassLoader()));
         this.setSource((User) in.readParcelable(User.class.getClassLoader()));
         this.setCircle((Circle) in.readParcelable(Circle.class.getClassLoader()));
-        this.setTimestamp(in.readLong());
         this.setImageUrl(in.readString());
     }
 
@@ -153,12 +138,12 @@ public class Quip extends BaseParseObject implements Parcelable {
                 // TODO: figure out how to query quips by only your facebook friends...
                 quips = getQuery()
                         .whereDoesNotExist(CIRCLE)
-                        .orderByDescending(TIMESTAMP)
+                        .orderByDescending(CREATED_AT)
                         .find();
             } else {
                 quips = getQuery()
                         .whereEqualTo(CIRCLE, circle.getObjectId())
-                        .orderByDescending(TIMESTAMP)
+                        .orderByDescending(CREATED_AT)
                         .find();
             }
         } catch (ParseException parseException) {

--- a/app/src/main/java/it/quip/android/util/FormatUtils.java
+++ b/app/src/main/java/it/quip/android/util/FormatUtils.java
@@ -1,5 +1,8 @@
 package it.quip.android.util;
 
+import android.text.format.DateUtils;
+
+import java.util.Scanner;
 import java.util.regex.Pattern;
 
 public class FormatUtils {
@@ -7,5 +10,40 @@ public class FormatUtils {
     public static final Pattern CIRCLE_PATTERN = Pattern.compile("(@[A-Za-z0-9_-]+)");
 
     public static final String CIRCLE_MENTION_COLOR = "#FD8917";
+
+    private static final int SECOND_IN_MILLISECONDS = 1000;
+    private static final String JUST_NOW = "just now";
+
+    public static String getRelativeTimeAgo(long timeInMillis) {
+        return getRelativeTimeAgo(timeInMillis, System.currentTimeMillis());
+    }
+
+    private static String getRelativeTimeAgo(long timeInMillis, long relativeTo) {
+        if (relativeTo - timeInMillis <= SECOND_IN_MILLISECONDS) {
+            return JUST_NOW;
+        } else {
+            String relativeDateCreated = DateUtils.getRelativeTimeSpanString(
+                    timeInMillis, relativeTo, DateUtils.SECOND_IN_MILLIS).toString();
+            return shortenDate(relativeDateCreated);
+        }
+    }
+
+    private static String shortenDate(String relativeDate) {
+        Scanner s = dateStringScanner(relativeDate);
+        if (s.hasNextInt()) {
+            int amount = s.nextInt();
+            String unit = s.next();
+            return String.format("%d%c", amount, unit.charAt(0));
+        } else {
+            // Date pattern that was a long time ago
+            return relativeDate;
+        }
+    }
+
+    private static Scanner dateStringScanner(String date) {
+        Scanner s = new Scanner(date);
+        s.useDelimiter(" ");
+        return s;
+    }
     
 }


### PR DESCRIPTION
Uses the real timestamp instead of `"2d"`. Also removes timestamp from the quip as it isn't necessary. It puts a `getTimestamp` method on the base parse object that will return the timestamp based on the createdAt time that is added to each parse object on save. If that timestamp is not there, it will return the current time.
